### PR TITLE
Conversion: added uppercase symbols for Celsius and Fahrenheit #4673

### DIFF
--- a/share/goodie/conversions/triggers.yml
+++ b/share/goodie/conversions/triggers.yml
@@ -1532,7 +1532,7 @@ aliases:
 can_be_negative: 1
 type: temperature
 unit: fahrenheit
-symbols: [°f]
+symbols: [°f,°F]
 ---
 aliases:
   - c
@@ -1547,7 +1547,7 @@ aliases:
 can_be_negative: 1
 type: temperature
 unit: celsius
-symbols: [°c]
+symbols: [°c,°C]
 ---
 aliases:
   - kelvin


### PR DESCRIPTION
<!-- 

***
DuckDuckHack is currently in Maintenance mode
Please read before submitting: https://duckduckhack.com
***

Use the following format for your Pull Request title above ^^^^^:

{IA Name}: {Description of change}

-->

## Description of new Instant Answer, or changes
<!-- What does this new Instant Answer do? What changes does this PR introduce? -->
Added °C and °F for Celsius and Fahrenheit symbols as mentioned in #4673. Results should be given for 40°C in °F.

## Related Issues and Discussions
<!-- Link related issues here to automatically close them when PR is merged -->
Fixes #4673


## People to notify
<!-- Please @mention any relevant people/organizations here: -->
@smilealdway @moollaza

<!-- DO NOT REMOVE -->
---

<!-- The Instant Answer ID can be found by clicking the `?` icon beside the Instant Answer result on DuckDuckGo.com -->
<!-- Instant Answer Page: https://duck.co/ia/view/{ID} [couldn't find the link]-->
<!-- FILL THIS IN:                           ^^^^ -->
